### PR TITLE
Fix esbuild version pinning causing build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"pnpm": {
 		"overrides": {
-			"esbuild": "0.21.4"
+			"esbuild": "0.27.0"
 		}
 	}
 }


### PR DESCRIPTION
Problem Description:
When using pnpm package manager, an error occurs during TypeScript compilation due to `template-starter`'s `package.json` using an older version of esbuild under pnpm.

Error Message:
```
npx wrangler dev

⛅️ wrangler 4.62.0
───────────────────

X [ERROR] Invalid target "es2024" in "--target=es2024"
```

Error Conditions:
`pnpm dev`
`pnpm run deploy`
`*Possibly* using a CommonJS package; in my project, it's pg 8.18.0`

Potentially related changes:
https://github.com/cloudflare/workers-sdk/issues/11530

Since issues is closed, I submitted a pull request.
I'm not sure why pnpm needs a fixed version number. Are there any known issues between pnpm and esbuild?